### PR TITLE
Fix problem with no_std deployments.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 
 [dependencies]
 embedded-hal = "0.2.2"
-bit_reverse = "0.1.7"
+bit_reverse = { version = "0.1.7", default-features = false }
 bitflags = "1.0"
 byteorder = { version = "1.2", default-features = false }
 


### PR DESCRIPTION
bit-reverse has a default feature that enables std. To make it work with no_std, this removes the default features, as described in the bit-reverse README file.