### PR TITLE
Relax embedded-hal dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [dependencies]
-embedded-hal = "=0.2.2"
+embedded-hal = "0.2"
 bit_reverse = { version = "0.1.7", default-features = false }
 bitflags = "1.0"
 byteorder = { version = "1.2", default-features = false }


### PR DESCRIPTION
This can break dependent crates (transitively) requiring higher versions.

I haven't found any reason for pinning to that specific revision of embedded-hal, despite c901cc63a52b3ee06330cb507e1190724c2009bf's message.