### PR TITLE
Update to newest non v1 of embedded-hal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [dependencies]
-embedded-hal = "=0.2.2"
+embedded-hal = "0.2.7"
 bit_reverse = { version = "0.1.7", default-features = false }
 bitflags = "1.0"
 byteorder = { version = "1.2", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ extern crate embedded_hal as hal;
 use bit_reverse::ParallelReverse;
 use core::fmt;
 use hal::blocking::spi;
-use hal::digital::OutputPin;
+use hal::digital::v2::OutputPin;
 
 use baton::Baton;
 use classic::{Classic, GamepadButtons};
@@ -295,7 +295,7 @@ where
     pub fn new(spi: SPI, mut select: Option<CS>) -> Self {
         // If a select pin was provided, disable the controller for now
         if let Some(ref mut x) = select {
-            x.set_high();
+            let _ = x.set_high();
         }
 
         Self {
@@ -329,13 +329,13 @@ where
         Self::flip(result);
 
         if let Some(ref mut x) = self.select {
-            x.set_low();
+            let _ = x.set_low();
         }
 
         self.dev.transfer(result)?;
 
         if let Some(ref mut x) = self.select {
-            x.set_high();
+            let _ = x.set_high();
         }
 
         Self::flip(result);


### PR DESCRIPTION
Updates the library to the most current 0.2.x version of embedded hal. Also fixed these deprecations and warnings after the update:

<details>

<summary>Warnings</summary>

```
➜ cargo check
warning: use of deprecated trait `hal::digital::OutputPin`: Deprecated because the methods cannot return errors. Users should use the traits in digital::v2.
  --> src/lib.rs:70:19
   |
70 | use hal::digital::OutputPin;
   |                   ^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated trait `hal::digital::OutputPin`: Deprecated because the methods cannot return errors. Users should use the traits in digital::v2.
   --> src/lib.rs:291:9
    |
291 |     CS: OutputPin,
    |         ^^^^^^^^^

warning: use of deprecated method `hal::digital::OutputPin::set_high`: Deprecated because the methods cannot return errors. Users should use the traits in digital::v2.
   --> src/lib.rs:298:15
    |
298 |             x.set_high();
    |               ^^^^^^^^

warning: use of deprecated method `hal::digital::OutputPin::set_low`: Deprecated because the methods cannot return errors. Users should use the traits in digital::v2.
   --> src/lib.rs:332:15
    |
332 |             x.set_low();
    |               ^^^^^^^

warning: use of deprecated method `hal::digital::OutputPin::set_high`: Deprecated because the methods cannot return errors. Users should use the traits in digital::v2.
   --> src/lib.rs:338:15
    |
338 |             x.set_high();
    |               ^^^^^^^^

warning: `pscontroller-rs` (lib) generated 5 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
```

</details>