### PR TITLE
Update to embedded-hal 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ exclude = [
 ]
 
 [dependencies]
-embedded-hal = "0.2.7"
+embedded-hal = "1.0.0"
 bit_reverse = { version = "0.1.7", default-features = false }
 bitflags = "1.0"
 byteorder = { version = "1.2", default-features = false }
 
 [dev-dependencies]
-linux-embedded-hal = "0.2.2"
+linux-embedded-hal = "0.4.0"

--- a/examples/baton.rs
+++ b/examples/baton.rs
@@ -2,9 +2,8 @@ extern crate bit_reverse;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpidevOptions, SPI_MODE_3};
-use linux_hal::Pin;
-use linux_hal::Spidev;
+use linux_hal::gpio_cdev::{Chip, LineHandle, LineRequestFlags};
+use linux_hal::spidev::{SpiModeFlags, Spidev, SpidevOptions};
 use std::io;
 
 use pscontroller_rs::PlayStationPort;
@@ -20,7 +19,7 @@ fn build_spi() -> io::Result<Spidev> {
     let opts = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(SPI_SPEED)
-        .mode(SPI_MODE_3)
+        .mode(SpiModeFlags::SPI_MODE_3)
         .build();
     spi.configure(&opts)?;
 
@@ -29,7 +28,7 @@ fn build_spi() -> io::Result<Spidev> {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None::<Pin>);
+    let mut psp = PlayStationPort::new(spi, None::<LineHandle>);
 
     let mut controller;
 

--- a/examples/baton.rs
+++ b/examples/baton.rs
@@ -2,8 +2,7 @@ extern crate bit_reverse;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::gpio_cdev::{Chip, LineHandle, LineRequestFlags};
-use linux_hal::spidev::{SpiModeFlags, Spidev, SpidevOptions};
+use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
 use std::io;
 
 use pscontroller_rs::PlayStationPort;
@@ -14,8 +13,8 @@ const SPI_DEVICE: &str = "/dev/spidev0.0";
 const SPI_SPEED: u32 = 10_000;
 
 // This will build the SPI device communication for us
-fn build_spi() -> io::Result<Spidev> {
-    let mut spi = Spidev::open(SPI_DEVICE)?;
+fn build_spi() -> io::Result<SpidevBus> {
+    let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(SPI_SPEED)
@@ -28,7 +27,7 @@ fn build_spi() -> io::Result<Spidev> {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None::<LineHandle>);
+    let mut psp = PlayStationPort::new(spi, None);
 
     let mut controller;
 

--- a/examples/baton.rs
+++ b/examples/baton.rs
@@ -3,7 +3,7 @@ extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
-use linux_hal::SpidevBus;
+use linux_hal::{CdevPin, SpidevBus};
 use std::io;
 
 use pscontroller_rs::PlayStationPort;
@@ -14,7 +14,7 @@ const SPI_DEVICE: &str = "/dev/spidev0.0";
 const SPI_SPEED: u32 = 10_000;
 
 // This will build the SPI device communication for us
-fn build_spi() -> io::Result<SpidevBus> {
+fn build_spi() -> Result<SpidevBus, Box<dyn std::error::Error>> {
     let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
@@ -28,7 +28,7 @@ fn build_spi() -> io::Result<SpidevBus> {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None);
+    let mut psp: PlayStationPort<_, CdevPin> = PlayStationPort::new(spi, None);
 
     let mut controller;
 

--- a/examples/baton.rs
+++ b/examples/baton.rs
@@ -4,7 +4,6 @@ extern crate pscontroller_rs;
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
 use linux_hal::{CdevPin, SpidevBus};
-use std::io;
 
 use pscontroller_rs::PlayStationPort;
 

--- a/examples/baton.rs
+++ b/examples/baton.rs
@@ -2,7 +2,8 @@ extern crate bit_reverse;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
+use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
+use linux_hal::SpidevBus;
 use std::io;
 
 use pscontroller_rs::PlayStationPort;

--- a/examples/console.rs
+++ b/examples/console.rs
@@ -2,8 +2,7 @@ extern crate embedded_hal;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::gpio_cdev::{Chip, LineHandle, LineRequestFlags};
-use linux_hal::spidev::{SpiModeFlags, Spidev, SpidevOptions};
+use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
 use std::io;
 use std::{thread, time};
 
@@ -17,8 +16,8 @@ const SPI_SPEED: u32 = 100_000;
 // and pass the pin into psp's new() function.
 //const SPI_ENABLE_PIN: u32 = 4;
 
-fn build_spi() -> io::Result<Spidev> {
-    let mut spi = Spidev::open(SPI_DEVICE)?;
+fn build_spi() -> io::Result<SpidevBus> {
+    let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(SPI_SPEED)
@@ -31,12 +30,13 @@ fn build_spi() -> io::Result<Spidev> {
 
 fn main() {
     let spi = build_spi().unwrap();
+    // Example of using GPIO pin for chip select:
     //const GPIO_CHIP: &str = "/dev/gpiochip0";
     //let mut chip = Chip::new(GPIO_CHIP).unwrap();
-    //let enable_pin = chip.get_line(SPI_ENABLE_PIN).unwrap()
-    //    .request(LineRequestFlags::OUTPUT, 1, "pscontroller").unwrap();
+    //let enable_pin = CdevPin::new(chip.get_line(SPI_ENABLE_PIN).unwrap()
+    //    .request(LineRequestFlags::OUTPUT, 1, "pscontroller").unwrap()).unwrap();
     //let mut psp = PlayStationPort::new(spi, Some(enable_pin));
-    let mut psp = PlayStationPort::new(spi, None::<LineHandle>);
+    let mut psp = PlayStationPort::new(spi, None);
     let mut command = [0u8; 32];
     let mut buffer = [0u8; 32];
 

--- a/examples/console.rs
+++ b/examples/console.rs
@@ -2,9 +2,8 @@ extern crate embedded_hal;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpidevOptions, SPI_MODE_3};
-use linux_hal::Pin;
-use linux_hal::Spidev;
+use linux_hal::gpio_cdev::{Chip, LineHandle, LineRequestFlags};
+use linux_hal::spidev::{SpiModeFlags, Spidev, SpidevOptions};
 use std::io;
 use std::{thread, time};
 
@@ -16,14 +15,14 @@ const SPI_DEVICE: &str = "/dev/spidev0.0";
 const SPI_SPEED: u32 = 100_000;
 // If you need to use an alternate pin for cable select, uncomment the relevant bits
 // and pass the pin into psp's new() function.
-//const SPI_ENABLE_PIN: u64 = 4;
+//const SPI_ENABLE_PIN: u32 = 4;
 
 fn build_spi() -> io::Result<Spidev> {
     let mut spi = Spidev::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(SPI_SPEED)
-        .mode(SPI_MODE_3)
+        .mode(SpiModeFlags::SPI_MODE_3)
         .build();
     spi.configure(&opts)?;
 
@@ -32,9 +31,12 @@ fn build_spi() -> io::Result<Spidev> {
 
 fn main() {
     let spi = build_spi().unwrap();
-    //let enable_pin = Pin::new(SPI_ENABLE_PIN);
+    //const GPIO_CHIP: &str = "/dev/gpiochip0";
+    //let mut chip = Chip::new(GPIO_CHIP).unwrap();
+    //let enable_pin = chip.get_line(SPI_ENABLE_PIN).unwrap()
+    //    .request(LineRequestFlags::OUTPUT, 1, "pscontroller").unwrap();
     //let mut psp = PlayStationPort::new(spi, Some(enable_pin));
-    let mut psp = PlayStationPort::new(spi, None::<Pin>);
+    let mut psp = PlayStationPort::new(spi, None::<LineHandle>);
     let mut command = [0u8; 32];
     let mut buffer = [0u8; 32];
 

--- a/examples/console.rs
+++ b/examples/console.rs
@@ -3,7 +3,7 @@ extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
-use linux_hal::SpidevBus;
+use linux_hal::{CdevPin, SpidevBus};
 use std::io;
 use std::{thread, time};
 
@@ -17,7 +17,7 @@ const SPI_SPEED: u32 = 100_000;
 // and pass the pin into psp's new() function.
 //const SPI_ENABLE_PIN: u32 = 4;
 
-fn build_spi() -> io::Result<SpidevBus> {
+fn build_spi() -> Result<SpidevBus, Box<dyn std::error::Error>> {
     let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
@@ -37,7 +37,7 @@ fn main() {
     //let enable_pin = CdevPin::new(chip.get_line(SPI_ENABLE_PIN).unwrap()
     //    .request(LineRequestFlags::OUTPUT, 1, "pscontroller").unwrap()).unwrap();
     //let mut psp = PlayStationPort::new(spi, Some(enable_pin));
-    let mut psp = PlayStationPort::new(spi, None);
+    let mut psp: PlayStationPort<_, CdevPin> = PlayStationPort::new(spi, None);
     let mut command = [0u8; 32];
     let mut buffer = [0u8; 32];
 

--- a/examples/console.rs
+++ b/examples/console.rs
@@ -2,7 +2,8 @@ extern crate embedded_hal;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
+use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
+use linux_hal::SpidevBus;
 use std::io;
 use std::{thread, time};
 

--- a/examples/console.rs
+++ b/examples/console.rs
@@ -30,12 +30,6 @@ fn build_spi() -> Result<SpidevBus, Box<dyn std::error::Error>> {
 
 fn main() {
     let spi = build_spi().unwrap();
-    // Example of using GPIO pin for chip select:
-    //const GPIO_CHIP: &str = "/dev/gpiochip0";
-    //let mut chip = Chip::new(GPIO_CHIP).unwrap();
-    //let enable_pin = CdevPin::new(chip.get_line(SPI_ENABLE_PIN).unwrap()
-    //    .request(LineRequestFlags::OUTPUT, 1, "pscontroller").unwrap()).unwrap();
-    //let mut psp = PlayStationPort::new(spi, Some(enable_pin));
     let mut psp: PlayStationPort<_, CdevPin> = PlayStationPort::new(spi, None);
     let mut command = [0u8; 32];
     let mut buffer = [0u8; 32];

--- a/examples/console.rs
+++ b/examples/console.rs
@@ -4,7 +4,6 @@ extern crate pscontroller_rs;
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
 use linux_hal::{CdevPin, SpidevBus};
-use std::io;
 use std::{thread, time};
 
 use pscontroller_rs::PlayStationPort;

--- a/examples/dualshock.rs
+++ b/examples/dualshock.rs
@@ -2,7 +2,8 @@ extern crate bit_reverse;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
+use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
+use linux_hal::SpidevBus;
 use std::io;
 
 use pscontroller_rs::{classic::GamepadButtons, dualshock::ControlDS, Device, PlayStationPort};

--- a/examples/dualshock.rs
+++ b/examples/dualshock.rs
@@ -3,7 +3,7 @@ extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
-use linux_hal::SpidevBus;
+use linux_hal::{CdevPin, SpidevBus};
 use std::io;
 
 use pscontroller_rs::{classic::GamepadButtons, dualshock::ControlDS, Device, PlayStationPort};
@@ -14,7 +14,7 @@ const SPI_DEVICE: &str = "/dev/spidev0.0";
 const SPI_SPEED: u32 = 10_000;
 
 // This will build the
-fn build_spi() -> io::Result<SpidevBus> {
+fn build_spi() -> Result<SpidevBus, Box<dyn std::error::Error>> {
     let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
@@ -46,7 +46,7 @@ fn set_motors(buttons: &GamepadButtons, small: &mut bool, big: &mut u8) {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None);
+    let mut psp: PlayStationPort<_, CdevPin> = PlayStationPort::new(spi, None);
     let mut control_ds = ControlDS::new(false, 0);
 
     let mut big: u8 = 0;

--- a/examples/dualshock.rs
+++ b/examples/dualshock.rs
@@ -2,7 +2,7 @@ extern crate bit_reverse;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpidevBus, SpidevOptions, SpiModeFlags};
+use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
 use std::io;
 
 use pscontroller_rs::{classic::GamepadButtons, dualshock::ControlDS, Device, PlayStationPort};

--- a/examples/dualshock.rs
+++ b/examples/dualshock.rs
@@ -2,9 +2,7 @@ extern crate bit_reverse;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpidevOptions, SPI_MODE_3};
-use linux_hal::Pin;
-use linux_hal::Spidev;
+use linux_hal::spidev::{SpidevBus, SpidevOptions, SpiModeFlags};
 use std::io;
 
 use pscontroller_rs::{classic::GamepadButtons, dualshock::ControlDS, Device, PlayStationPort};
@@ -15,12 +13,12 @@ const SPI_DEVICE: &str = "/dev/spidev0.0";
 const SPI_SPEED: u32 = 10_000;
 
 // This will build the
-fn build_spi() -> io::Result<Spidev> {
-    let mut spi = Spidev::open(SPI_DEVICE)?;
+fn build_spi() -> io::Result<SpidevBus> {
+    let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(SPI_SPEED)
-        .mode(SPI_MODE_3)
+        .mode(SpiModeFlags::SPI_MODE_3)
         .build();
     spi.configure(&opts)?;
 
@@ -47,7 +45,7 @@ fn set_motors(buttons: &GamepadButtons, small: &mut bool, big: &mut u8) {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None::<Pin>);
+    let mut psp = PlayStationPort::new(spi, None);
     let mut control_ds = ControlDS::new(false, 0);
 
     let mut big: u8 = 0;

--- a/examples/dualshock.rs
+++ b/examples/dualshock.rs
@@ -4,7 +4,6 @@ extern crate pscontroller_rs;
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
 use linux_hal::{CdevPin, SpidevBus};
-use std::io;
 
 use pscontroller_rs::{classic::GamepadButtons, dualshock::ControlDS, Device, PlayStationPort};
 

--- a/examples/guitarhero.rs
+++ b/examples/guitarhero.rs
@@ -3,7 +3,7 @@ extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
-use linux_hal::SpidevBus;
+use linux_hal::{CdevPin, SpidevBus};
 use std::io;
 
 use pscontroller_rs::PlayStationPort;
@@ -14,7 +14,7 @@ const SPI_DEVICE: &str = "/dev/spidev0.0";
 const SPI_SPEED: u32 = 10_000;
 
 // This will build the
-fn build_spi() -> io::Result<SpidevBus> {
+fn build_spi() -> Result<SpidevBus, Box<dyn std::error::Error>> {
     let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
@@ -28,7 +28,7 @@ fn build_spi() -> io::Result<SpidevBus> {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None);
+    let mut psp: PlayStationPort<_, CdevPin> = PlayStationPort::new(spi, None);
 
     let mut controller;
 

--- a/examples/guitarhero.rs
+++ b/examples/guitarhero.rs
@@ -4,7 +4,6 @@ extern crate pscontroller_rs;
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
 use linux_hal::{CdevPin, SpidevBus};
-use std::io;
 
 use pscontroller_rs::PlayStationPort;
 

--- a/examples/guitarhero.rs
+++ b/examples/guitarhero.rs
@@ -2,9 +2,7 @@ extern crate bit_reverse;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpidevOptions, SPI_MODE_3};
-use linux_hal::Pin;
-use linux_hal::Spidev;
+use linux_hal::spidev::{SpidevBus, SpidevOptions, SpiModeFlags};
 use std::io;
 
 use pscontroller_rs::PlayStationPort;
@@ -15,12 +13,12 @@ const SPI_DEVICE: &str = "/dev/spidev0.0";
 const SPI_SPEED: u32 = 10_000;
 
 // This will build the
-fn build_spi() -> io::Result<Spidev> {
-    let mut spi = Spidev::open(SPI_DEVICE)?;
+fn build_spi() -> io::Result<SpidevBus> {
+    let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(SPI_SPEED)
-        .mode(SPI_MODE_3)
+        .mode(SpiModeFlags::SPI_MODE_3)
         .build();
     spi.configure(&opts)?;
 
@@ -29,7 +27,7 @@ fn build_spi() -> io::Result<Spidev> {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None::<Pin>);
+    let mut psp = PlayStationPort::new(spi, None);
 
     let mut controller;
 

--- a/examples/guitarhero.rs
+++ b/examples/guitarhero.rs
@@ -2,7 +2,7 @@ extern crate bit_reverse;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpidevBus, SpidevOptions, SpiModeFlags};
+use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
 use std::io;
 
 use pscontroller_rs::PlayStationPort;

--- a/examples/guitarhero.rs
+++ b/examples/guitarhero.rs
@@ -2,7 +2,8 @@ extern crate bit_reverse;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
+use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
+use linux_hal::SpidevBus;
 use std::io;
 
 use pscontroller_rs::PlayStationPort;

--- a/examples/jogcon.rs
+++ b/examples/jogcon.rs
@@ -10,7 +10,7 @@ extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
-use linux_hal::SpidevBus;
+use linux_hal::{CdevPin, SpidevBus};
 use std::io;
 
 use pscontroller_rs::{
@@ -23,7 +23,7 @@ use pscontroller_rs::{
 const SPI_DEVICE: &str = "/dev/spidev0.0";
 const SPI_SPEED: u32 = 10_000;
 
-fn build_spi() -> io::Result<SpidevBus> {
+fn build_spi() -> Result<SpidevBus, Box<dyn std::error::Error>> {
     let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
@@ -37,7 +37,7 @@ fn build_spi() -> io::Result<SpidevBus> {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None);
+    let mut psp: PlayStationPort<_, CdevPin> = PlayStationPort::new(spi, None);
     let mut control_jc = ControlJC::new(JogControl::Stop, 15);
 
     psp.enable_jogcon()

--- a/examples/jogcon.rs
+++ b/examples/jogcon.rs
@@ -9,7 +9,7 @@ extern crate embedded_hal;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpidevBus, SpidevOptions, SpiModeFlags};
+use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
 use std::io;
 
 use pscontroller_rs::{

--- a/examples/jogcon.rs
+++ b/examples/jogcon.rs
@@ -9,7 +9,8 @@ extern crate embedded_hal;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
+use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
+use linux_hal::SpidevBus;
 use std::io;
 
 use pscontroller_rs::{

--- a/examples/jogcon.rs
+++ b/examples/jogcon.rs
@@ -11,7 +11,6 @@ extern crate pscontroller_rs;
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
 use linux_hal::{CdevPin, SpidevBus};
-use std::io;
 
 use pscontroller_rs::{
     jogcon::{ControlJC, JogControl},

--- a/examples/jogcon.rs
+++ b/examples/jogcon.rs
@@ -9,9 +9,7 @@ extern crate embedded_hal;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpidevOptions, SPI_MODE_3};
-use linux_hal::Pin;
-use linux_hal::Spidev;
+use linux_hal::spidev::{SpidevBus, SpidevOptions, SpiModeFlags};
 use std::io;
 
 use pscontroller_rs::{
@@ -24,12 +22,12 @@ use pscontroller_rs::{
 const SPI_DEVICE: &str = "/dev/spidev0.0";
 const SPI_SPEED: u32 = 10_000;
 
-fn build_spi() -> io::Result<Spidev> {
-    let mut spi = Spidev::open(SPI_DEVICE)?;
+fn build_spi() -> io::Result<SpidevBus> {
+    let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(SPI_SPEED)
-        .mode(SPI_MODE_3)
+        .mode(SpiModeFlags::SPI_MODE_3)
         .build();
     spi.configure(&opts)?;
 
@@ -38,7 +36,7 @@ fn build_spi() -> io::Result<Spidev> {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None::<Pin>);
+    let mut psp = PlayStationPort::new(spi, None);
     let mut control_jc = ControlJC::new(JogControl::Stop, 15);
 
     psp.enable_jogcon()

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -3,9 +3,8 @@ extern crate pscontroller_rs;
 
 use std::{io, thread, time};
 
-use linux_hal::spidev::{SpidevOptions, SPI_MODE_3};
-use linux_hal::Pin;
-use linux_hal::Spidev;
+use linux_hal::gpio_cdev::{Chip, LineHandle, LineRequestFlags};
+use linux_hal::spidev::{SpiModeFlags, Spidev, SpidevOptions};
 
 use pscontroller_rs::{Device, PlayStationPort};
 
@@ -20,7 +19,7 @@ fn build_spi() -> io::Result<Spidev> {
     let opts = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(SPI_SPEED)
-        .mode(SPI_MODE_3)
+        .mode(SpiModeFlags::SPI_MODE_3)
         .build();
     spi.configure(&opts)?;
 
@@ -29,7 +28,7 @@ fn build_spi() -> io::Result<Spidev> {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None::<Pin>);
+    let mut psp = PlayStationPort::new(spi, None::<LineHandle>);
     let sleep_duration = time::Duration::from_millis(10);
 
     let mut x: i32 = 0;

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -1,7 +1,7 @@
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use std::{io, thread, time};
+use std::{thread, time};
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
 use linux_hal::{CdevPin, SpidevBus};

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -3,8 +3,7 @@ extern crate pscontroller_rs;
 
 use std::{io, thread, time};
 
-use linux_hal::gpio_cdev::{Chip, LineHandle, LineRequestFlags};
-use linux_hal::spidev::{SpiModeFlags, Spidev, SpidevOptions};
+use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
 
 use pscontroller_rs::{Device, PlayStationPort};
 
@@ -14,8 +13,8 @@ const SPI_DEVICE: &str = "/dev/spidev0.0";
 const SPI_SPEED: u32 = 100_000;
 
 // This will build the
-fn build_spi() -> io::Result<Spidev> {
-    let mut spi = Spidev::open(SPI_DEVICE)?;
+fn build_spi() -> io::Result<SpidevBus> {
+    let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(SPI_SPEED)
@@ -28,7 +27,7 @@ fn build_spi() -> io::Result<Spidev> {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None::<LineHandle>);
+    let mut psp = PlayStationPort::new(spi, None);
     let sleep_duration = time::Duration::from_millis(10);
 
     let mut x: i32 = 0;

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -3,7 +3,8 @@ extern crate pscontroller_rs;
 
 use std::{io, thread, time};
 
-use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
+use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
+use linux_hal::SpidevBus;
 
 use pscontroller_rs::{Device, PlayStationPort};
 

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -4,7 +4,7 @@ extern crate pscontroller_rs;
 use std::{io, thread, time};
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
-use linux_hal::SpidevBus;
+use linux_hal::{CdevPin, SpidevBus};
 
 use pscontroller_rs::{Device, PlayStationPort};
 
@@ -14,7 +14,7 @@ const SPI_DEVICE: &str = "/dev/spidev0.0";
 const SPI_SPEED: u32 = 100_000;
 
 // This will build the
-fn build_spi() -> io::Result<SpidevBus> {
+fn build_spi() -> Result<SpidevBus, Box<dyn std::error::Error>> {
     let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
@@ -28,7 +28,7 @@ fn build_spi() -> io::Result<SpidevBus> {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None);
+    let mut psp: PlayStationPort<_, CdevPin> = PlayStationPort::new(spi, None);
     let sleep_duration = time::Duration::from_millis(10);
 
     let mut x: i32 = 0;

--- a/examples/playstation.rs
+++ b/examples/playstation.rs
@@ -2,8 +2,7 @@ extern crate bit_reverse;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::gpio_cdev::{Chip, LineHandle, LineRequestFlags};
-use linux_hal::spidev::{SpiModeFlags, Spidev, SpidevOptions};
+use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
 use std::io;
 
 use pscontroller_rs::{Device, PlayStationPort};
@@ -14,8 +13,8 @@ const SPI_DEVICE: &str = "/dev/spidev0.0";
 const SPI_SPEED: u32 = 100_000;
 
 // This will build the
-fn build_spi() -> io::Result<Spidev> {
-    let mut spi = Spidev::open(SPI_DEVICE)?;
+fn build_spi() -> io::Result<SpidevBus> {
+    let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(SPI_SPEED)
@@ -35,7 +34,7 @@ fn dump_hex(buffer: &[u8]) {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None::<LineHandle>);
+    let mut psp = PlayStationPort::new(spi, None);
 
     psp.enable_pressure().unwrap();
 

--- a/examples/playstation.rs
+++ b/examples/playstation.rs
@@ -3,7 +3,7 @@ extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
-use linux_hal::SpidevBus;
+use linux_hal::{CdevPin, SpidevBus};
 use std::io;
 
 use pscontroller_rs::{Device, PlayStationPort};
@@ -14,7 +14,7 @@ const SPI_DEVICE: &str = "/dev/spidev0.0";
 const SPI_SPEED: u32 = 100_000;
 
 // This will build the
-fn build_spi() -> io::Result<SpidevBus> {
+fn build_spi() -> Result<SpidevBus, Box<dyn std::error::Error>> {
     let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
@@ -35,7 +35,7 @@ fn dump_hex(buffer: &[u8]) {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None);
+    let mut psp: PlayStationPort<_, CdevPin> = PlayStationPort::new(spi, None);
 
     psp.enable_pressure().unwrap();
 

--- a/examples/playstation.rs
+++ b/examples/playstation.rs
@@ -2,7 +2,8 @@ extern crate bit_reverse;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
+use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
+use linux_hal::SpidevBus;
 use std::io;
 
 use pscontroller_rs::{Device, PlayStationPort};

--- a/examples/playstation.rs
+++ b/examples/playstation.rs
@@ -2,9 +2,8 @@ extern crate bit_reverse;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpidevOptions, SPI_MODE_3};
-use linux_hal::Pin;
-use linux_hal::Spidev;
+use linux_hal::gpio_cdev::{Chip, LineHandle, LineRequestFlags};
+use linux_hal::spidev::{SpiModeFlags, Spidev, SpidevOptions};
 use std::io;
 
 use pscontroller_rs::{Device, PlayStationPort};
@@ -20,7 +19,7 @@ fn build_spi() -> io::Result<Spidev> {
     let opts = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(SPI_SPEED)
-        .mode(SPI_MODE_3)
+        .mode(SpiModeFlags::SPI_MODE_3)
         .build();
     spi.configure(&opts)?;
 
@@ -36,7 +35,7 @@ fn dump_hex(buffer: &[u8]) {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None::<Pin>);
+    let mut psp = PlayStationPort::new(spi, None::<LineHandle>);
 
     psp.enable_pressure().unwrap();
 

--- a/examples/playstation.rs
+++ b/examples/playstation.rs
@@ -4,7 +4,6 @@ extern crate pscontroller_rs;
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
 use linux_hal::{CdevPin, SpidevBus};
-use std::io;
 
 use pscontroller_rs::{Device, PlayStationPort};
 

--- a/examples/scanner.rs
+++ b/examples/scanner.rs
@@ -2,9 +2,7 @@ extern crate embedded_hal;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpidevOptions, SPI_MODE_3};
-use linux_hal::Pin;
-use linux_hal::Spidev;
+use linux_hal::spidev::{SpidevBus, SpidevOptions, SpiModeFlags};
 use std::io;
 use std::{thread, time};
 
@@ -26,12 +24,12 @@ const SCAN_RESPONSE_WIDTH: u8 = 10;
 const SAMPLE_PAUSE: u64 = 0_000;
 const USE_MULTITAP: bool = false;
 
-fn build_spi() -> io::Result<Spidev> {
-    let mut spi = Spidev::open(SPI_DEVICE)?;
+fn build_spi() -> io::Result<SpidevBus> {
+    let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(SPI_SPEED)
-        .mode(SPI_MODE_3)
+        .mode(SpiModeFlags::SPI_MODE_3)
         .build();
     spi.configure(&opts)?;
 
@@ -40,7 +38,7 @@ fn build_spi() -> io::Result<Spidev> {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None::<Pin>);
+    let mut psp = PlayStationPort::new(spi, None);
     let mut command = [0u8; SCAN_RESPONSE_WIDTH as usize];
     let mut buffer = [0u8; SCAN_RESPONSE_WIDTH as usize];
     let mut _dummy = [0u8; SCAN_RESPONSE_WIDTH as usize];

--- a/examples/scanner.rs
+++ b/examples/scanner.rs
@@ -3,7 +3,7 @@ extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
-use linux_hal::SpidevBus;
+use linux_hal::{CdevPin, SpidevBus};
 use std::io;
 use std::{thread, time};
 
@@ -25,7 +25,7 @@ const SCAN_RESPONSE_WIDTH: u8 = 10;
 const SAMPLE_PAUSE: u64 = 0_000;
 const USE_MULTITAP: bool = false;
 
-fn build_spi() -> io::Result<SpidevBus> {
+fn build_spi() -> Result<SpidevBus, Box<dyn std::error::Error>> {
     let mut spi = SpidevBus::open(SPI_DEVICE)?;
     let opts = SpidevOptions::new()
         .bits_per_word(8)
@@ -39,7 +39,7 @@ fn build_spi() -> io::Result<SpidevBus> {
 
 fn main() {
     let spi = build_spi().unwrap();
-    let mut psp = PlayStationPort::new(spi, None);
+    let mut psp: PlayStationPort<_, CdevPin> = PlayStationPort::new(spi, None);
     let mut command = [0u8; SCAN_RESPONSE_WIDTH as usize];
     let mut buffer = [0u8; SCAN_RESPONSE_WIDTH as usize];
     let mut _dummy = [0u8; SCAN_RESPONSE_WIDTH as usize];

--- a/examples/scanner.rs
+++ b/examples/scanner.rs
@@ -4,7 +4,6 @@ extern crate pscontroller_rs;
 
 use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
 use linux_hal::{CdevPin, SpidevBus};
-use std::io;
 use std::{thread, time};
 
 use pscontroller_rs::{MultitapPort, PlayStationPort};

--- a/examples/scanner.rs
+++ b/examples/scanner.rs
@@ -2,7 +2,7 @@ extern crate embedded_hal;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpidevBus, SpidevOptions, SpiModeFlags};
+use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
 use std::io;
 use std::{thread, time};
 

--- a/examples/scanner.rs
+++ b/examples/scanner.rs
@@ -2,7 +2,8 @@ extern crate embedded_hal;
 extern crate linux_embedded_hal as linux_hal;
 extern crate pscontroller_rs;
 
-use linux_hal::spidev::{SpiModeFlags, SpidevBus, SpidevOptions};
+use linux_hal::spidev::{SpiModeFlags, SpidevOptions};
+use linux_hal::SpidevBus;
 use std::io;
 use std::{thread, time};
 


### PR DESCRIPTION
A few misc changes:

The transfer method in embedded-hal 1.0.0 is called transfer_in_place

And some generic errors are now SPI::Error